### PR TITLE
[infra] feat: add missing CODEOWNERS [sc-235082]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+atlantis.yaml         @ThirtyMadison/infra


### PR DESCRIPTION
feat: add codeowners where missing [sc-235082]